### PR TITLE
Add ability to export FBX from split objects

### DIFF
--- a/AssetStudioCLI/AssetStudioCLI.csproj
+++ b/AssetStudioCLI/AssetStudioCLI.csproj
@@ -26,12 +26,16 @@
         <Message Text="Copying windows extra files for $(TargetFramework)... " Importance="high" />
         <Copy SourceFiles="$(SolutionDir)Texture2DDecoderNative\bin\Win32\$(Configuration)\Texture2DDecoderNative.dll" DestinationFolder="$(TargetDir)runtimes\win-x86\native" ContinueOnError="false" />
         <Copy SourceFiles="$(SolutionDir)Texture2DDecoderNative\bin\x64\$(Configuration)\Texture2DDecoderNative.dll" DestinationFolder="$(TargetDir)runtimes\win-x64\native" ContinueOnError="false" />
+        <Copy SourceFiles="$(SolutionDir)AssetStudioFBXNative\bin\Win32\$(Configuration)\AssetStudioFBXNative.dll" DestinationFolder="$(TargetDir)runtimes\win-x86\native" ContinueOnError="false" />
+        <Copy SourceFiles="$(SolutionDir)AssetStudioFBXNative\bin\x64\$(Configuration)\AssetStudioFBXNative.dll" DestinationFolder="$(TargetDir)runtimes\win-x64\native" ContinueOnError="false" />
         <Copy SourceFiles="$(ProjectDir)Libraries\win-x86\fmod.dll" DestinationFolder="$(TargetDir)runtimes\win-x86\native" ContinueOnError="false" />
         <Copy SourceFiles="$(ProjectDir)Libraries\win-x64\fmod.dll" DestinationFolder="$(TargetDir)runtimes\win-x64\native" ContinueOnError="false" />
     </Target>
 
     <Target Name="CopyExtraFilesPortableNet" AfterTargets="AfterBuild" Condition=" '$(RuntimeIdentifier)' == '' AND '$(TargetFramework)' != 'net472' ">
         <Message Text="Copying other platforms extra files for $(TargetFramework)... " Importance="high" />
+        <Copy SourceFiles="$(TargetDir)runtimes\win-x86\native\AssetStudioFBXNative.dll" DestinationFolder="$(PublishDir)runtimes\win-x86\native" ContinueOnError="false" />
+        <Copy SourceFiles="$(TargetDir)runtimes\win-x64\native\AssetStudioFBXNative.dll" DestinationFolder="$(PublishDir)runtimes\win-x64\native" ContinueOnError="false" />
         <Copy SourceFiles="$(ProjectDir)Libraries\linux-x86\libfmod.so" DestinationFolder="$(TargetDir)runtimes\linux-x86\native" ContinueOnError="false" />
         <Copy SourceFiles="$(ProjectDir)Libraries\linux-x64\libfmod.so" DestinationFolder="$(TargetDir)runtimes\linux-x64\native" ContinueOnError="false" />
         <Copy SourceFiles="$(ProjectDir)Libraries\osx-x64\libfmod.dylib" DestinationFolder="$(TargetDir)runtimes\osx-x64\native" ContinueOnError="false" />
@@ -59,17 +63,20 @@
     <Target Name="CopyExtraFilesWin86" AfterTargets="AfterBuild" Condition=" '$(RuntimeIdentifier)' == 'win-x86' ">
         <Message Text="Copying extra files for $(RuntimeIdentifier)($(TargetFramework))... " Importance="high" />
         <Copy SourceFiles="$(SolutionDir)Texture2DDecoderNative\bin\Win32\$(Configuration)\Texture2DDecoderNative.dll" DestinationFolder="$(TargetDir)" ContinueOnError="false" />
+        <Copy SourceFiles="$(SolutionDir)AssetStudioFBXNative\bin\Win32\$(Configuration)\AssetStudioFBXNative.dll" DestinationFolder="$(TargetDir)" ContinueOnError="false" />
         <Copy SourceFiles="$(ProjectDir)Libraries\win-x86\fmod.dll" DestinationFolder="$(TargetDir)" ContinueOnError="false" />
     </Target>
 
     <Target Name="CopyExtraFilesWin64" AfterTargets="AfterBuild" Condition=" '$(RuntimeIdentifier)' == 'win-x64' ">
         <Message Text="Copying extra files for $(RuntimeIdentifier)($(TargetFramework))... " Importance="high" />
         <Copy SourceFiles="$(SolutionDir)Texture2DDecoderNative\bin\x64\$(Configuration)\Texture2DDecoderNative.dll" DestinationFolder="$(TargetDir)" ContinueOnError="false" />
+        <Copy SourceFiles="$(SolutionDir)AssetStudioFBXNative\bin\x64\$(Configuration)\AssetStudioFBXNative.dll" DestinationFolder="$(TargetDir)" ContinueOnError="false" />
         <Copy SourceFiles="$(ProjectDir)Libraries\win-x64\fmod.dll" DestinationFolder="$(TargetDir)" ContinueOnError="false" />
     </Target>
 
     <Target Name="PublishExtraFilesWin" AfterTargets="Publish" Condition=" $(RuntimeIdentifier.Contains('win-x')) ">
         <Message Text="Publishing extra files for $(RuntimeIdentifier)($(TargetFramework))... " Importance="high" />
+        <Copy SourceFiles="$(TargetDir)\AssetStudioFBXNative.dll" DestinationFolder="$(PublishDir)" ContinueOnError="false" />
         <Copy SourceFiles="$(TargetDir)\Texture2DDecoderNative.dll" DestinationFolder="$(PublishDir)" ContinueOnError="false" />
         <Copy SourceFiles="$(TargetDir)\fmod.dll" DestinationFolder="$(PublishDir)" ContinueOnError="false" />
     </Target>
@@ -77,21 +84,25 @@
     <Target Name="CopyExtraFilesLinux64" AfterTargets="AfterBuild" Condition=" '$(RuntimeIdentifier)' == 'linux-x64' ">
         <Message Text="Copying extra files for $(RuntimeIdentifier)($(TargetFramework))... " Importance="high" />
         <Copy SourceFiles="$(ProjectDir)Libraries\linux-x64\libfmod.so" DestinationFolder="$(TargetDir)" ContinueOnError="false" />
+        <Copy SourceFiles="$(ProjectDir)Libraries\linux-x64\libAssetStudioFBXNative.so" DestinationFolder="$(TargetDir)" ContinueOnError="false" />
     </Target>
 
     <Target Name="PublishExtraFilesLinux64" AfterTargets="Publish" Condition=" '$(RuntimeIdentifier)' == 'linux-x64' ">
         <Message Text="Publishing extra files for $(RuntimeIdentifier)($(TargetFramework))... " Importance="high" />
         <Copy SourceFiles="$(TargetDir)\libfmod.so" DestinationFolder="$(PublishDir)" ContinueOnError="false" />
+        <Copy SourceFiles="$(TargetDir)\libAssetStudioFBXNative.so" DestinationFolder="$(PublishDir)" ContinueOnError="false" />
     </Target>
 
     <Target Name="CopyExtraFilesMac" AfterTargets="AfterBuild" Condition=" $(RuntimeIdentifier.Contains('osx-')) ">
         <Message Text="Copying extra files for $(RuntimeIdentifier)($(TargetFramework))... " Importance="high" />
         <Copy SourceFiles="$(ProjectDir)Libraries\$(RuntimeIdentifier)\libfmod.dylib" DestinationFolder="$(TargetDir)" ContinueOnError="false" />
+        <Copy SourceFiles="$(ProjectDir)Libraries\$(RuntimeIdentifier)\libAssetStudioFBXNative.dylib" DestinationFolder="$(TargetDir)" ContinueOnError="false" />
     </Target>
 
     <Target Name="PublishExtraFilesMac" AfterTargets="Publish" Condition=" $(RuntimeIdentifier.Contains('osx-')) ">
         <Message Text="Publishing extra files for $(RuntimeIdentifier)($(TargetFramework))... " Importance="high" />
         <Copy SourceFiles="$(TargetDir)\libfmod.dylib" DestinationFolder="$(PublishDir)" ContinueOnError="false" />
+        <Copy SourceFiles="$(TargetDir)\libAssetStudioFBXNative.dylib" DestinationFolder="$(PublishDir)" ContinueOnError="false" />
     </Target>
 
 </Project>

--- a/AssetStudioCLI/Components/AssetItem.cs
+++ b/AssetStudioCLI/Components/AssetItem.cs
@@ -13,6 +13,7 @@ namespace AssetStudioCLI
         public ClassIDType Type;
         public string Text;
         public string UniqueID;
+        public GameObjectNode Node;
 
         public AssetItem(Object asset)
         {

--- a/AssetStudioCLI/Components/BaseNode.cs
+++ b/AssetStudioCLI/Components/BaseNode.cs
@@ -1,0 +1,16 @@
+using AssetStudio;
+using System.Collections.Generic;
+
+namespace AssetStudioCLI
+{
+    internal class BaseNode
+    {
+        public List<BaseNode> nodes = new List<BaseNode>();
+
+        public BaseNode()
+        {
+            
+        }
+
+    }
+}

--- a/AssetStudioCLI/Components/GameObjectNode.cs
+++ b/AssetStudioCLI/Components/GameObjectNode.cs
@@ -1,0 +1,16 @@
+using AssetStudio;
+using System.Collections.Generic;
+
+namespace AssetStudioCLI
+{
+    internal class GameObjectNode : BaseNode
+    {
+        public GameObject gameObject;
+
+        public GameObjectNode(GameObject gameObject)
+        {
+            this.gameObject = gameObject;
+        }
+
+    }
+}

--- a/AssetStudioCLI/Exporter.cs
+++ b/AssetStudioCLI/Exporter.cs
@@ -1,6 +1,7 @@
 ﻿using AssetStudio;
 using AssetStudioCLI.Options;
 using Newtonsoft.Json;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -263,6 +264,34 @@ namespace AssetStudioCLI
             Logger.Debug($"{item.TypeString} \"{item.Text}\" exported to \"{exportFullPath}\"");
             return true;
         }
+
+        public static void ExportGameObject(GameObject gameObject, string exportPath, List<AssetItem> animationList = null)
+        {
+            var convert = animationList != null
+                ? new ModelConverter(gameObject, CLIOptions.o_imageFormat.Value, animationList.Select(x => (AnimationClip)x.Asset).ToArray())
+                : new ModelConverter(gameObject, CLIOptions.o_imageFormat.Value);
+            exportPath = exportPath + FixFileName(gameObject.m_Name) + ".fbx";
+            ExportFbx(convert, exportPath);
+        }
+
+        private static void ExportFbx(IImported convert, string exportPath)
+        {
+            var eulerFilter = true;
+            var filterPrecision = (float)0.25f;
+            var exportAllNodes = true;
+            var exportSkins = true;
+            var exportAnimations = true;
+            var exportBlendShape = true;
+            var castToBone = false;
+            var boneSize = CLIOptions.o_fbxBoneSize.Value;
+            var exportAllUvsAsDiffuseMaps = false;
+            var scaleFactor = CLIOptions.o_fbxScaleFactor.Value;
+            var fbxVersion = 3;
+            var fbxFormat = 0;
+            ModelExporter.ExportFbx(exportPath, convert, eulerFilter, filterPrecision,
+                exportAllNodes, exportSkins, exportAnimations, exportBlendShape, castToBone, boneSize, exportAllUvsAsDiffuseMaps, scaleFactor, fbxVersion, fbxFormat == 1);
+        }
+
 
         public static bool ExportDumpFile(AssetItem item, string exportPath)
         {

--- a/AssetStudioCLI/Options/CLIOptions.cs
+++ b/AssetStudioCLI/Options/CLIOptions.cs
@@ -12,6 +12,7 @@ namespace AssetStudioCLI.Options
         General,
         Convert,
         Logger,
+        FBX,
         Advanced,
     }
 
@@ -22,6 +23,7 @@ namespace AssetStudioCLI.Options
         Dump,
         Info,
         ExportLive2D,
+        SplitObjects,
     }
 
     internal enum AssetGroupOption
@@ -79,6 +81,9 @@ namespace AssetStudioCLI.Options
         public static bool convertTexture;
         public static Option<ImageFormat> o_imageFormat;
         public static Option<AudioFormat> o_audioFormat;
+        //fbx
+        public static Option<float> o_fbxScaleFactor;
+        public static Option<int> o_fbxBoneSize;
         //advanced
         public static Option<ExportListType> o_exportAssetList;
         public static Option<List<string>> o_filterByName;
@@ -158,6 +163,7 @@ namespace AssetStudioCLI.Options
                     "Dump - Makes asset dumps\n" +
                     "Info - Loads file(s), shows the number of available for export assets and exits\n" +
                     "Live2D - Exports Live2D Cubism 3 models\n" +
+                    "SplitObjects - Export split objects\n" +
                     "Example: \"-m info\"\n",
                 optionHelpGroup: HelpGroups.General
             );
@@ -246,6 +252,27 @@ namespace AssetStudioCLI.Options
                     "None - Do not convert audios and export them in their own format\n" +
                     "Example: \"--audio-format wav\"",
                 optionHelpGroup: HelpGroups.Convert
+            );
+            #endregion
+
+            #region Init FBX Options
+            o_fbxScaleFactor = new GroupedOption<float>
+            (
+                optionDefaultValue: 1f,
+                optionName: "--fbx-scale-factor <value>",
+                optionDescription: "Specify the FBX Scale Factor\n" +
+                    "<Value: float number from 0 to 100 (default=1)\n" +
+                    "Example: \"--fbx-scale-factor 50\"\n",
+                optionHelpGroup: HelpGroups.FBX
+            );
+            o_fbxBoneSize = new GroupedOption<int>
+            (
+                optionDefaultValue: 10,
+                optionName: "--fbx-bone-size <value>",
+                optionDescription: "Specify the FBX Bone Size\n" +
+                    "<Value: integer number from 0 to 100 (default=10)\n" +
+                    "Example: \"--fbx-bone-size 10\"",
+                optionHelpGroup: HelpGroups.FBX
             );
             #endregion
 
@@ -419,6 +446,19 @@ namespace AssetStudioCLI.Options
                                         ClassIDType.MonoBehaviour,
                                         ClassIDType.Texture2D,
                                         ClassIDType.Transform,
+                                    };
+                                    break;
+                                case "splitobjects":
+                                    o_workMode.Value = WorkMode.SplitObjects;
+                                    o_exportAssetTypes.Value = new List<ClassIDType>()
+                                    {
+                                        ClassIDType.GameObject,
+                                        ClassIDType.Texture2D,
+                                        ClassIDType.Material,
+                                        ClassIDType.Transform,
+                                        ClassIDType.Mesh,
+                                        ClassIDType.MeshRenderer,
+                                        ClassIDType.MeshFilter
                                     };
                                     break;
                                 default:
@@ -615,6 +655,32 @@ namespace AssetStudioCLI.Options
                                     Console.WriteLine($"{"Error".Color(brightRed)} during parsing [{option}] option. Unsupported audio format: [{value.Color(brightRed)}].\n");
                                     Console.WriteLine(o_audioFormat.Description);
                                     return;
+                            }
+                            break;
+                        case "--fbx-scale-factor":
+                            var isFloat = float.TryParse(value, out float floatValue);
+                            if (isFloat && floatValue >= 0 && floatValue <= 100)
+                            {
+                                o_fbxScaleFactor.Value = floatValue;
+                            }
+                            else
+                            {
+                                Console.WriteLine($"{"Error".Color(brightRed)} during parsing [{option}] option. Unsupported scale factor value: [{value.Color(brightRed)}].\n");
+                                Console.WriteLine(o_fbxScaleFactor.Description);
+                                return;
+                            }
+                            break;
+                        case "--fbx-bone-size":
+                            var isInt = int.TryParse(value, out int intValue);
+                            if (isInt && intValue >= 0 && intValue <= 100)
+                            {
+                                o_fbxBoneSize.Value = intValue;
+                            }
+                            else
+                            {
+                                Console.WriteLine($"{"Error".Color(brightRed)} during parsing [{option}] option. Unsupported bone size value: [{value.Color(brightRed)}].\n");
+                                Console.WriteLine(o_fbxBoneSize.Description);
+                                return;
                             }
                             break;
                         case "--export-asset-list":

--- a/AssetStudioCLI/Program.cs
+++ b/AssetStudioCLI/Program.cs
@@ -51,6 +51,9 @@ namespace AssetStudioCLI
                         case WorkMode.ExportLive2D:
                             Studio.ExportLive2D();
                             break;
+                        case WorkMode.SplitObjects:
+                            Studio.ExportSplitObjects();
+                            break;
                         default:
                             Studio.ExportAssets();
                             break;

--- a/AssetStudioCLI/ReadMe.md
+++ b/AssetStudioCLI/ReadMe.md
@@ -24,6 +24,7 @@ General Options:
                                 Dump - Makes asset dumps
                                 Info - Loads file(s), shows the number of available for export assets and exits
                                 Live2D - Exports Live2D Cubism 3 models
+                                SplitObjects - Export split objects
                                 Example: "-m info"
 
   -t, --asset-type <value(s)>   Specify asset type(s) to export
@@ -66,6 +67,15 @@ Convert Options:
                                 <Value: none | wav(default)>
                                 None - Do not convert audios and export them in their own format
                                 Example: "--audio-format wav"
+
+FBX Options:
+  --fbx-scale-factor <value>    Specify the FBX Scale Factor
+                                <Value: float number from 0 to 100 (default=1)
+                                Example: "--fbx-scale-factor 50"
+                                
+  --fbx-bone-size <value>       Specify the FBX Bone Size
+                                <Value: integer number from 0 to 100 (default=10)
+                                Example: "--fbx-bone-size 10"
 
 Advanced Options:
   --export-asset-list <value>   Specify the format in which you want to export asset list

--- a/AssetStudioFBXNative/CMakeLists.txt
+++ b/AssetStudioFBXNative/CMakeLists.txt
@@ -1,0 +1,22 @@
+# Set the minimum version of CMake that can be used
+cmake_minimum_required (VERSION 3.8)
+
+# Set the project name
+project("AssetStudioFBXNative")
+
+# Set the C++ standard to C++ 14
+set(CMAKE_CXX_STANDARD 14)
+
+# Generate the shared library from the library sources
+add_library(AssetStudioFBXNative SHARED
+    asfbx_skin_context.cpp
+    asfbx_morph_context.cpp
+    api.cpp
+    utils.cpp
+    asfbx_context.cpp
+    asfbx_anim_context.cpp)
+
+# Add the given directories to those the compiler uses to search for include files
+target_include_directories(AssetStudioFBXNative PRIVATE .)
+
+target_link_libraries(AssetStudioFBXNative PRIVATE fbxsdk xml2)


### PR DESCRIPTION
Allows for exporting FBX files from the CLI, like with the option Model > Export all objects (split) in the GUI.

Example usage:
`AssetStudioModCLI <file> -o output/ -m splitobjects --fbx-scale-factor 100`