### PR TITLE
Fix parsing secondary textures

### DIFF
--- a/AssetStudio/Classes/Sprite.cs
+++ b/AssetStudio/Classes/Sprite.cs
@@ -12,7 +12,7 @@ namespace AssetStudio
         public SecondarySpriteTexture(ObjectReader reader)
         {
             texture = new PPtr<Texture2D>(reader);
-            name = reader.ReadStringToNull();
+            name = reader.ReadAlignedString();
         }
     }
 


### PR DESCRIPTION
Fixed parsing bug of SecondarySpriteTexture.
Tested on bundles from Unity 2022.3.8