### PR TITLE
Mesh lookup if Renderer is missing a mesh reference during Animator export

### DIFF
--- a/AssetStudioGUI/AssetStudioGUIForm.cs
+++ b/AssetStudioGUI/AssetStudioGUIForm.cs
@@ -2714,7 +2714,7 @@ namespace AssetStudioGUI
             GL.GenVertexArrays(1, out vao);
             GL.BindVertexArray(vao);
             CreateVBO(out var vboPositions, vertexData, attributeVertexPosition);
-            if (normalMode == 0)
+            if (normalMode == 1)
             {
                 CreateVBO(out var vboNormals, normal2Data, attributeNormalDirection);
             }

--- a/AssetStudioUtility/ModelConverter.cs
+++ b/AssetStudioUtility/ModelConverter.cs
@@ -589,6 +589,30 @@ namespace AssetStudio
                 }
             }
 
+            // Last resort
+#if DEBUG
+            Console.WriteLine($"Mesh Renderer had no mesh attached during export, resorting to dumb name search among assets");
+#endif
+            GameObject go;
+            if (meshR.m_GameObject.TryGet(out go))
+            {
+                string meshR_originalName = go.m_Name;
+                foreach (var serializedFile in go.assetsFile.assetsManager.assetsFileList)
+                {
+                    //var nameRelatedMesh = serializedFile.Objects.FirstOrDefault(o => (o is Mesh) && (o as NamedObject).m_Name == meshR_originalName, null);
+                    // It's not possible to hot-reload lambdas with captures.
+                    // I'm not gonna reload 50 GB worth of assets in RAM in debug again for the code to look fancy.
+                    foreach (var o in serializedFile.Objects)
+                        if (o is Mesh && (o as Mesh).m_Name == meshR_originalName)
+                        {
+#if DEBUG
+                            Console.WriteLine($"Found a replacement Mesh succesfully for the component {meshR_originalName} which has no mesh attached");
+#endif
+                            return o as Mesh;
+                        }
+                }
+            }
+
             return null;
         }
 


### PR DESCRIPTION
Some Animators may be used as templates for use with skin variants, hence their m_Mesh may be null in the hierarchy as those are set at runtime. This becomes a problem, for example, when exporting GameObjects or Animators with such templates (as for example NagantSR0101 among GirlsFrontline 2 assets in any of its variants will export no meshes).
Looks like those components still contain the name of the mesh they come with, so the app will now try to use that name to look up the missing mesh in the entirety of loaded assets. This enables:
1) Export in fbx as Animators are exported in fbx by default.
2) Skeleton and skinning weights are exported (unlike .obj).
3) Makes use of the structure available and visible regardless of m_Mesh being null or not.
It may not be guaranteed, of course, depends on the game assets.