### PR TITLE
fix bundle blocks read failed with ArchiveFlags.BlocksInfoAtTheEnd

### DIFF
--- a/AssetStudio/BundleFile.cs
+++ b/AssetStudio/BundleFile.cs
@@ -298,7 +298,7 @@ namespace AssetStudio
             if ((m_Header.flags & ArchiveFlags.BlocksInfoAtTheEnd) != 0)
             {
                 var position = reader.Position;
-                reader.Position = reader.BaseStream.Length - m_Header.compressedBlocksInfoSize;
+                reader.Position = m_Header.size - m_Header.compressedBlocksInfoSize;
                 blocksInfoBytes = reader.ReadBytes((int)m_Header.compressedBlocksInfoSize);
                 reader.Position = position;
             }


### PR DESCRIPTION
Bundle files may be aligned and padding with zeros. Previously `ArchiveFlags.BlocksInfoAtTheEnd` will read the end padding zeros rather than the real block infos, causing decompression errors in following logics.
![image](https://github.com/aelurum/AssetStudio/assets/13981123/4dc08c0b-ce6b-4e8f-915e-447048bd8e94)
