### PR TITLE
Enable CI build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,8 @@
 name: AssetStudioBuild
 
 on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+  push: {}
+  pull_request: {}
 
   workflow_dispatch:
 
@@ -13,8 +11,8 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: microsoft/setup-msbuild@v1.1
+      - uses: actions/checkout@v4
+      - uses: microsoft/setup-msbuild@v2
       
       - name: Download FBX SDK
         run: |
@@ -32,26 +30,26 @@ jobs:
       - name: Build .Net472
         run: msbuild /p:Configuration=Release /p:TargetFramework=net472 /verbosity:minimal
 
-      - name: Build .Net5
-        run: msbuild /t:AssetStudioGUI:publish /p:Configuration=Release /p:TargetFramework=net5.0-windows /p:SelfContained=false /verbosity:minimal
-
       - name: Build .Net6
         run: msbuild /t:AssetStudioGUI:publish /p:Configuration=Release /p:TargetFramework=net6.0-windows /p:SelfContained=false /verbosity:minimal
 
+      - name: Build .Net8
+        run: msbuild /t:AssetStudioGUI:publish /p:Configuration=Release /p:TargetFramework=net8.0-windows /p:SelfContained=false /verbosity:minimal
+
       - name: Upload .Net472 Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: AssetStudio.net472
           path: AssetStudioGUI/bin/Release/net472
 
-      - name: Upload .Net5 Artifact
-        uses: actions/upload-artifact@v2
+      - name: Upload .Net6 Artifact
+        uses: actions/upload-artifact@v4
         with:
           name: AssetStudio.net5
-          path: AssetStudioGUI/bin/Release/net5.0-windows/publish
+          path: AssetStudioGUI/bin/Release/net6.0-windows/publish
 
-      - name: Upload .Net6 Artifact
-        uses: actions/upload-artifact@v2
+      - name: Upload .Net8 Artifact
+        uses: actions/upload-artifact@v4
         with:
           name: AssetStudio.net6
-          path: AssetStudioGUI/bin/Release/net6.0-windows/publish
+          path: AssetStudioGUI/bin/Release/net8.0-windows/publish

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,11 +30,11 @@ jobs:
       - name: Build .Net472
         run: msbuild /p:Configuration=Release /p:TargetFramework=net472 /verbosity:minimal
 
-      - name: Build .Net6
-        run: msbuild /t:AssetStudioGUI:publish /p:Configuration=Release /p:TargetFramework=net6.0-windows /p:SelfContained=false /verbosity:minimal
-
       - name: Build .Net8
         run: msbuild /t:AssetStudioGUI:publish /p:Configuration=Release /p:TargetFramework=net8.0-windows /p:SelfContained=false /verbosity:minimal
+
+      - name: Build .Net9
+        run: msbuild /t:AssetStudioGUI:publish /p:Configuration=Release /p:TargetFramework=net9.0-windows /p:SelfContained=false /verbosity:minimal
 
       - name: Upload .Net472 Artifact
         uses: actions/upload-artifact@v4
@@ -42,14 +42,14 @@ jobs:
           name: AssetStudio.net472
           path: AssetStudioGUI/bin/Release/net472
 
-      - name: Upload .Net6 Artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: AssetStudio.net5
-          path: AssetStudioGUI/bin/Release/net6.0-windows/publish
-
       - name: Upload .Net8 Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: AssetStudio.net6
+          name: AssetStudio.net8
           path: AssetStudioGUI/bin/Release/net8.0-windows/publish
+
+      - name: Upload .Net9 Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: AssetStudio.net9
+          path: AssetStudioGUI/bin/Release/net9.0-windows/publish


### PR DESCRIPTION
Now CI build will works again, on any branch when it was updated.
This file needs to be updated after the following components are updated：
 - FBX SDK version
 - dotnet version add or remove