### PR TITLE
Fix CLI `--mode animator` not exporting AnimationClip with `--fbx-animation all`, and add support for `--fbx-uvs-as-diffuse`, add FBX ASCII format support for CLI

### DIFF
--- a/AssetStudioCLI/Exporter.cs
+++ b/AssetStudioCLI/Exporter.cs
@@ -287,6 +287,7 @@ namespace AssetStudioCLI
                 ScaleFactor = CLIOptions.o_fbxScaleFactor.Value,
                 ExportAllUvsAsDiffuseMaps = CLIOptions.f_fbxUvsAsDiffuseMaps.Value,
                 ExportAnimations = CLIOptions.o_fbxAnimMode.Value != AnimationExportMode.Skip,
+                FbxFormat = CLIOptions.f_fbxAsciiFormat.Value == true ? 1 : 0,
             };
             ModelExporter.ExportFbx(exportPath, convert, fbxSettings);
         }

--- a/AssetStudioCLI/Options/CLIOptions.cs
+++ b/AssetStudioCLI/Options/CLIOptions.cs
@@ -679,6 +679,7 @@ namespace AssetStudioCLI.Options
                         o_exportAssetTypes.Value = new List<ClassIDType>
                         {
                             ClassIDType.Animator,
+                            ClassIDType.AnimationClip,
                             ClassIDType.Mesh,
                             ClassIDType.Texture2D,
                         };

--- a/AssetStudioCLI/Options/CLIOptions.cs
+++ b/AssetStudioCLI/Options/CLIOptions.cs
@@ -727,7 +727,7 @@ namespace AssetStudioCLI.Options
                         flagIndexes.Add(i);
                         break;
                     case "--fbx-uvs-as-diffuse":
-                        if (o_workMode.Value != WorkMode.SplitObjects)
+                        if (o_workMode.Value != WorkMode.SplitObjects && o_workMode.Value != WorkMode.Animator)
                         {
                             Console.WriteLine($"{"Error".Color(brightRed)} during parsing [{flag.Color(brightYellow)}] flag. This flag is not suitable for the current working mode [{o_workMode.Value}].\n");
                             ShowOptionDescription(o_workMode);

--- a/AssetStudioCLI/Options/CLIOptions.cs
+++ b/AssetStudioCLI/Options/CLIOptions.cs
@@ -112,6 +112,7 @@ namespace AssetStudioCLI.Options
         public static Option<int> o_fbxBoneSize;
         public static Option<AnimationExportMode> o_fbxAnimMode;
         public static Option<bool> f_fbxUvsAsDiffuseMaps;
+        public static Option<bool> f_fbxAsciiFormat;
         //filter
         public static Option<List<string>> o_filterByName;
         public static Option<List<string>> o_filterByContainer;
@@ -407,7 +408,16 @@ namespace AssetStudioCLI.Options
                 optionName: "--fbx-uvs-as-diffuse",
                 optionDescription: "(Flag) If specified, Studio will export all UVs as Diffuse maps.\n" +
                     "Сan be useful if you cannot find some UVs after exporting (e.g. in Blender)\n" +
-                    "(But can also cause some bugs with UVs)",
+                    "(But can also cause some bugs with UVs)\n",
+                optionExample: "",
+                optionHelpGroup: HelpGroups.FBX
+            );
+            f_fbxAsciiFormat = new GroupedOption<bool>
+            (
+                optionDefaultValue: false,
+                optionName: "--fbx-ascii-format",
+                optionDescription: "(Flag) If specified, Studio will export FBX in ASCII format.\n" +
+                    "If not specified, Binary format will be used",
                 optionExample: "",
                 optionHelpGroup: HelpGroups.FBX
             );
@@ -734,6 +744,10 @@ namespace AssetStudioCLI.Options
                             return;
                         }
                         f_fbxUvsAsDiffuseMaps.Value = true;
+                        flagIndexes.Add(i);
+                        break;
+                    case "--fbx-ascii-format":
+                        f_fbxAsciiFormat.Value = true;
                         flagIndexes.Add(i);
                         break;
                     case "--filter-with-regex":
@@ -1482,6 +1496,7 @@ namespace AssetStudioCLI.Options
                     sb.AppendLine($"# FBX Bone Size: {o_fbxBoneSize}");
                     sb.AppendLine($"# FBX Animation Mode: {o_fbxAnimMode}");
                     sb.AppendLine($"# FBX UVs as Diffuse Maps: {f_fbxUvsAsDiffuseMaps}");
+                    sb.AppendLine($"# FBX Export in ASCII Format: {f_fbxAsciiFormat}");
                     break;
             }
             sb.AppendLine("======");


### PR DESCRIPTION
## 1. Fix `--fbx-animation all` not working with `--mode animator`

with CLI option `--mode animator --fbx-animation all` it should export **Animator + AnimationClips**, but it fails to add **AnimationClips** because the type is not added to the `o_exportAssetTypes` list

as seen in [`ExportAnimator()`, Studio.cs:961](https://github.com/aelurum/AssetStudio/blob/AssetStudioMod/AssetStudioCLI/Studio.cs#L961), it has an `exportAllAnimations` flag which adds **AnimationClips** to `animationList`, but because all **AnimationClips** is filtered out, nothing will be added

```cs
public static void ExportAnimator()
{
    var animationList = CLIOptions.o_fbxAnimMode.Value == AnimationExportMode.Auto
        ? null
        : new List<AssetItem>();
    // `animationList` exists if `--fbx-animation` is set to all/skip

    var exportAllAnimations = CLIOptions.o_fbxAnimMode.Value == AnimationExportMode.All;
    // true if `--fbx-animation all`

    Logger.Info("Searching for Animator assets...");
    var animatorList = new List<AssetItem>();
    foreach (var asset in parsedAssetsList) // `AnimationClip`s is filtered out
    {
        switch (asset.Type)
        {
            case ClassIDType.Animator:
                animatorList.Add(asset);
                break;
            case ClassIDType.AnimationClip when exportAllAnimations:
                animationList?.Add(asset); // never reaches
                break;
```

as observed, `parsedAssetsList` is added by `ParseAssets()`, and the exportable filtering logic is located at [Studio.cs:332](https://github.com/aelurum/AssetStudio/blob/AssetStudioMod/AssetStudioCLI/Studio.cs#L332)

```cs
isExportable = CLIOptions.o_exportAssetTypes.Value.Contains(asset.type); // filter by `o_exportAssetTypes`
if (isExportable || (CLIOptions.f_loadAllAssets.Value && CLIOptions.o_exportAssetTypes.Value == CLIOptions.o_exportAssetTypes.DefaultValue))
{
    fileAssetsList.Add(assetItem);
}
```

by adding `ClassIDType.AnimationClip` to `o_exportAssetTypes` in `WorkMode.Animator`, **AnimationClip**s are kept and animations will be exported in the model

it is sure that `AnimationExportMode.All` (`--fbx-animation all`) is designed to use here because this is the only reference to it

<img width="881" height="417" alt="image" src="https://github.com/user-attachments/assets/a921cca8-f009-4f87-b927-b5cd5d1de8e0" />

## 2. Fix the 'unsupported' message for `--fbx-uvs-as-diffuse` in `--mode animator`

`--fbx-uvs-as-diffuse` is designed to work with FBX export where `WorkMode.SplitObjects` does, but `WorkMode.Animator` also does this job. Both these two modes should accept this flag

## 3. Added CLI option `--fbx-ascii-format`

With this switch, FBX will be exported in ASCII format, otherwise in Binary.