### PR TITLE
Fix Exception when exporting an Animator | Fix null reference exception when bone frame is not found 

### DIFF
--- a/AssetStudioFBXWrapper/FbxExporterContext.cs
+++ b/AssetStudioFBXWrapper/FbxExporterContext.cs
@@ -228,19 +228,18 @@ namespace AssetStudio.FbxInterop
 
                     foreach (var bone in boneList)
                     {
+                        var cluster = IntPtr.Zero;
                         if (bone.Path != null)
                         {
                             var frame = rootFrame.FindFrameByPath(bone.Path);
-                            var boneNode = _frameToNode[frame];
 
-                            var cluster = AsFbxMeshCreateCluster(_pContext, boneNode);
-
-                            AsFbxMeshAddCluster(pClusterArray, cluster);
+                            if (frame != null)
+                            {
+                                var boneNode = _frameToNode[frame];
+                                cluster = AsFbxMeshCreateCluster(_pContext, boneNode);
+                            }
                         }
-                        else
-                        {
-                            AsFbxMeshAddCluster(pClusterArray, IntPtr.Zero);
-                        }
+                        AsFbxMeshAddCluster(pClusterArray, cluster);
                     }
                 }
 


### PR DESCRIPTION
Fixes this error
```
[Error] Export Animator:Eli error
[Error]
[Error] System.ArgumentNullException: Value cannot be null.
[Error] Parameter name: key
[Error]    at System.ThrowHelper.ThrowArgumentNullException(ExceptionArgument argument)
[Error]    at System.Collections.Generic.Dictionary`2.FindEntry(TKey key)
[Error]    at System.Collections.Generic.Dictionary`2.get_Item(TKey key)
[Error]    at AssetStudio.FbxInterop.FbxExporterContext.ExportMesh(ImportedFrame rootFrame, List`1 materialList, List`1 textureList, IntPtr frameNode, ImportedMesh importedMesh, Boolean exportSkins, Boolean exportAllUvsAsDiffuseMaps) in L:\GIT\ArknightsStudio\AssetStudioFBXWrapper\FbxExporterContext.cs:line 229
[Error]    at AssetStudio.FbxInterop.FbxExporter.ExportMeshFrames(ImportedFrame rootFrame, List`1 meshFrames) in L:\GIT\ArknightsStudio\AssetStudioFBXWrapper\FbxExporter.cs:line 174
[Error]    at AssetStudio.FbxInterop.FbxExporter.ExportAll(Boolean blendShape, Boolean animation, Boolean eulerFilter, Single filterPrecision) in L:\GIT\ArknightsStudio\AssetStudioFBXWrapper\FbxExporter.cs:line 93
[Error]    at AssetStudio.Fbx.Exporter.Export(String path, IImported imported, Boolean eulerFilter, Single filterPrecision, Boolean allNodes, Boolean skins, Boolean animation, Boolean blendShape, Boolean castToBone, Single boneSize, Boolean exportAllUvsAsDiffuseMaps, Single scaleFactor, Int32 versionIndex, Boolean isAscii) in L:\GIT\ArknightsStudio\AssetStudioFBXWrapper\Fbx.cs:line 53
[Error]    at AssetStudioGUI.Exporter.ExportFbx(IImported convert, String exportPath) in L:\GIT\ArknightsStudio\AssetStudioGUI\Exporter.cs:line 398
[Error]    at AssetStudioGUI.Exporter.ExportAnimator(AssetItem item, String exportPath, List`1 animationList) in L:\GIT\ArknightsStudio\AssetStudioGUI\Exporter.cs:line 361
[Error]    at AssetStudioGUI.Studio.<>c__DisplayClass14_0.<ExportAssets>b__0(Object state) in L:\GIT\ArknightsStudio\AssetStudioGUI\Studio.cs:line 487
```

Fix null reference exception when bone frame is not found

Add null check for frame lookup result before accessing _frameToNode dictionary.
Previously, if FindFrameByPath returned null, the code would throw a 
NullReferenceException when trying to use the frame as a dictionary key.

Now properly handles missing frames by passing IntPtr.Zero to AsFbxMeshAddCluster,
consistent with the original null path handling.