### PR TITLE
Update Kyaru.Texture2DDecoder package versions

### DIFF
--- a/AssetStudioUtility/AssetStudioUtility.csproj
+++ b/AssetStudioUtility/AssetStudioUtility.csproj
@@ -13,12 +13,12 @@
     </ItemGroup>
 
     <ItemGroup Condition=" !$(TargetFramework.Contains('windows')) ">
-        <PackageReference Include="Kyaru.Texture2DDecoder.Linux" Version="0.1.0" />
-        <PackageReference Include="Kyaru.Texture2DDecoder.macOS" Version="0.1.0" />
+        <PackageReference Include="Kyaru.Texture2DDecoder.Linux" Version="0.2.0" />
+        <PackageReference Include="Kyaru.Texture2DDecoder.macOS" Version="0.2.0" />
     </ItemGroup>
     
     <ItemGroup Condition=" '$(TargetFramework)' != 'net472' ">
-        <PackageReference Include="Kyaru.Texture2DDecoder.Windows" Version="0.1.0" />
+        <PackageReference Include="Kyaru.Texture2DDecoder.Windows" Version="0.2.0" />
         <PackageReference Include="Kyaru.Texture2DDecoder">
             <Version>0.17.0</Version>
         </PackageReference>


### PR DESCRIPTION
This PR updates the version of Kyaru.Texture2DDecoder.<OS>

This change adds a linux-arm64 binary to Kyaru.Texture2DDecoder.Linux. That is all. I bumped all 3 versions because the way the release works created v0.2.0 for all 3.

It appears these packages are not used for AssetStudioCLI or GUI however if a project is based on a fork of this repository (which is what led to me getting this update) then the AssetStudioUtility namespace providing them saves a lot of effort and works fine. I felt I should make this PR because of that.

For more details on updates to Kyaru.Texture2DDecoder.Linux see https://github.com/KiruyaMomochi/Texture2DDecoder/pull/4